### PR TITLE
Disc/track values as integers and submission_client fix

### DIFF
--- a/src/play.cpp
+++ b/src/play.cpp
@@ -141,9 +141,14 @@ namespace lbz
 					{
 						additional_info["albumartist"] = value;
 					}
-					if (name == "tracknumber")
+					else if (name == "discnumber" || name == "totaldiscs" || name == "totaltracks" || name == "tracknumber")
 					{
-						additional_info[name] = stoi(value);
+						try {
+							additional_info[name] = stoi(value);
+						}
+						catch (const std::invalid_argument& e) {
+							additional_info[name] = value;
+						}
 					}
 					else
 					{

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -141,6 +141,10 @@ namespace lbz
 					{
 						additional_info["albumartist"] = value;
 					}
+					if (name == "tracknumber")
+					{
+						additional_info[name] = stoi(value);
+					}
 					else
 					{
 						additional_info[name] = value;

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -192,7 +192,7 @@ namespace lbz
 			if (prefs::check_client_details.get_value()) {
 				additional_info["media_player"] = "foobar2000";
 				additional_info["media_player_version"] = core_version_info_v2::get()->get_version_as_text();
-				additional_info["submission_client"] = "foobar2000";
+				additional_info["submission_client"] = "foo_listenbrainz2";
 				additional_info["submission_client_version"] = component_version;
 			}
 


### PR DESCRIPTION
- Submit `discnumber`, `totaldiscs`, `totaltracks`, and `tracknumber` as integers instead of as strings.
    - If `stoi()` fails to read a number, e.g. value is `A1`, submit as string. If value is `1/16`, value submitted as integer (`1`).
- Submit `submission_client` as `foo_listenbrainz2` instead of `foobar2000`.

`discnumber`, `totaldiscs`, and `totaltracks` appear to be non-standard keys so could instead be removed (not listed on the [ListenBrainz JSON documentation](https://listenbrainz.readthedocs.io/en/latest/users/json.html)).

Closes #12
Closes #13