### PR TITLE
Set listened_at to start of playback

### DIFF
--- a/src/play.cpp
+++ b/src/play.cpp
@@ -254,7 +254,8 @@ namespace lbz
 			else if (type == listen_type::single)
 			{
 				j["listen_type"] = "single";
-				j["payload"][0]["listened_at"] = pfc::fileTimeWtoU(pfc::fileTimeNow());
+				// Set listening time to start of playback
+				j["payload"][0]["listened_at"] = pfc::fileTimeWtoU(pfc::fileTimeNow()) - m_counter;
 			}
 
 			const char* album = info.meta_get("album", 0);


### PR DESCRIPTION
This is more consistent with most other integrations and the prefered way of setting this timestamp.

I keep this open until https://github.com/metabrainz/listenbrainz-server/pull/2607 and the discussion at https://community.metabrainz.org/t/listened-at-parameter-for-submissions-specification-unclear/659142 have been resolved.