### PR TITLE
Use LB server if API URL is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Enter your [ListenBrainz token](https://listenbrainz.org/profile) and check the 
 
 ![Preferences](preferences.png)
 
-If you use another ListenBrainz compatible server, also adjust the URL. Make sure to append `/submit-listens` to the standard API URL of your server. Otherwise you will get `500` response errors.
+By default the component submits to the ListenBrainz server using the endpoint `https://api.listenbrainz.org/1/submit-listens`.
+
+If you use another ListenBrainz compatible server, also adjust the URL and use a token provided by your server. Make sure to append `/submit-listens` to the standard API URL of your server. Otherwise you will get `500` response errors. For [Maloja](https://github.com/krateng/maloja) servers the API URL is in the form of `https://{hostname}/apis/listenbrainz/1/submit-listens`.
 
 Now just listen to your music and watch the `Console` for server responses and/or check your recent listens page.
 

--- a/src/http_task.cpp
+++ b/src/http_task.cpp
@@ -74,7 +74,7 @@ namespace lbz
 
 		try
 		{
-			auto response = request->run_ex(prefs::str_api_url, fb2k::noAbort);
+			auto response = request->run_ex(get_api_url(), fb2k::noAbort);
 			response->read_string_raw(buffer, fb2k::noAbort);
 
 			json j = json::parse(buffer.get_ptr(), nullptr, false);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -61,6 +61,7 @@ namespace lbz
 
 			m_edit_api_url = GetDlgItem(IDC_EDIT_API_URL);
 			pfc::setWindowText(m_edit_api_url, prefs::str_api_url);
+			m_edit_api_url.SetCueBannerText(pfc::stringcvt::string_os_from_utf8(prefs::defaults::str_api_url));
 			m_edit_api_url.EnableWindow(enabled);
 
 			m_edit_query = GetDlgItem(IDC_EDIT_QUERY);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -36,11 +36,28 @@ namespace lbz
 		extern cfg_string str_cache;
 	}
 
+	static const char* get_api_url()
+	{
+		if (strlen(prefs::str_api_url.get_ptr()) == 0)
+		{
+			return prefs::defaults::str_api_url;
+		}
+		else
+		{
+			return prefs::str_api_url;
+		}
+	}
+
 	// Returns true, if the API URL is the default ListenBrainz service.
 	static bool is_listenbrainz()
 	{
-		if (strcmp(prefs::str_api_url.get_ptr(), prefs::defaults::str_api_url) == 0) return true;
-		
+		const char* api_url = prefs::str_api_url.get_ptr();
+		if (strlen(api_url) == 0
+			|| strcmp(api_url, prefs::defaults::str_api_url) == 0)
+		{
+			return true;
+		}
+
 		return false;
 	}
 
@@ -48,11 +65,11 @@ namespace lbz
 	{
 		// empty token
 		if (prefs::str_user_token.get_ptr() == nullptr) return false;
-		// Default ListenBrainz service 
+		// Default ListenBrainz service
 		if (is_listenbrainz()) return is_uuid(prefs::str_user_token.get_ptr());
 		// Custom server
 		if (strlen(prefs::str_user_token.get_ptr()) > 0) return true;
-		
+
 		return false;
 	}
 }


### PR DESCRIPTION
This changes the API URL preference to use the ListenBrainz server if it is empty. This simplifies the configuration a bit as it is easier to go back to default config. If the text edit field is empty it shows the default URL as a cue.

Also extends the README a bit, explicitly describing setup with Maloja (as it might be a common use case).